### PR TITLE
Feature/performance tuning of adding tags

### DIFF
--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -188,6 +188,30 @@ open class TagListView: UIView {
         }
     }
     
+    open var needScaleAnimate: Bool = false {
+        didSet {
+            tagViews.forEach {
+                $0.needScaleAnimate = needScaleAnimate
+            }
+        }
+    }
+
+    open var shrinkingScale: CGFloat? {
+        didSet {
+            tagViews.forEach {
+                $0.shrinkingScale = shrinkingScale!
+            }
+        }
+    }
+
+    open var expandingScale: CGFloat? {
+        didSet {
+            tagViews.forEach {
+                $0.expandingScale = expandingScale!
+            }
+        }
+    }
+    
     /// The desired (maximum) width of the whole view. This needs to be set in cases where
     /// the `intrinsicContentSize` should to be calculated before or without the view being
     /// previously layouted. For example when using `systemLayoutSizeFitting:`.
@@ -372,7 +396,6 @@ open class TagListView: UIView {
     open func insertTag(_ title: String, at index: Int) -> TagView {
         return insertTagView(createNewTagView(title), at: index)
     }
-    
 
     @discardableResult
     open func insertTagView(_ tagView: TagView, at index: Int) -> TagView {
@@ -419,7 +442,6 @@ open class TagListView: UIView {
     // MARK: - Events
     
     @objc func tagPressed(_ sender: TagView!) {
-        sender.onTap?(sender)
         delegate?.tagPressed?(sender.currentTitle ?? "", tagView: sender, sender: self)
     }
     

--- a/TagListView/TagListView.swift
+++ b/TagListView/TagListView.swift
@@ -196,18 +196,18 @@ open class TagListView: UIView {
         }
     }
 
-    open var shrinkingScale: CGFloat? {
+    open var shrinkingScale: CGFloat = 0.9 {
         didSet {
             tagViews.forEach {
-                $0.shrinkingScale = shrinkingScale!
+                $0.shrinkingScale = shrinkingScale
             }
         }
     }
 
-    open var expandingScale: CGFloat? {
+    open var expandingScale: CGFloat = 1.3 {
         didSet {
             tagViews.forEach {
-                $0.expandingScale = expandingScale!
+                $0.expandingScale = expandingScale
             }
         }
     }

--- a/TagListView/TagView.swift
+++ b/TagListView/TagView.swift
@@ -185,7 +185,7 @@ open class TagView: UIButton {
         self.addTarget(self, action: #selector(self.didTouchDragOutside) , for: .touchCancel)
         self.addTarget(self, action: #selector(self.didTouchDown)        , for: .touchDragEnter)
         self.addTarget(self, action: #selector(self.didTouchUpInside)    , for: .touchUpInside)
-        self.addTarget(self, action: #selector(self.didTouchUpInside)    , for: .touchUpOutside)
+        self.addTarget(self, action: #selector(self.didTouchDragOutside)    , for: .touchUpOutside)
         
         let longPress = UILongPressGestureRecognizer(target: self, action: #selector(self.longPress))
         self.addGestureRecognizer(longPress)


### PR DESCRIPTION
# 概要
- 1年前くらいにPR出した #1 で、タグ追加時のパフォーマンスが劣化してしまっていたので、その対応
- 独自のスケールアニメーションの追加

## 経緯
めちゃコミでTagListViewのタグの高さが正しく取れない問題があって、1年前くらいに #1 で対応をしました。

最近、Uraracaでも同様の対応が必要になって、導入したところタグの件数が多いViewで極端にパフォーマンスが劣化していることが発覚しました。

## 修正内容
- 1年前くらいに出したPRで、タグ追加時のパフォーマンスが劣化してしまっていたので、その対応

  - `@discardableResult open func addTags(_ titles: [String]) -> [TagView]`でtitleを複数件渡して、
  タグを追加するときに、1件追加する度に、高さを計算し直すための `全部remove → 全部addSubview`を実行してしまっていたので、最後に1回だけ実行するよう修正

- 独自のスケールアニメーションの追加
  - めちゃコミやUraracaで利用しているタグタップ時のアニメーションも、こちらのPRに含んでいます🙇‍♂️
 
## 補足
[UraracaのPRにも説明書いてます。](https://github.com/andfactory/uraraca-ios/pull/589)